### PR TITLE
Add full API 16 testing to Circle CI and test doze on API 24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,70 @@ jobs:
             set -e
             python -m pytest -v tests/adbe_tests.py  --durations=0
 
-  test-python3:
+  test-python3-android-api-16:
+    docker:
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: circleci/android:api-28-alpha
+        environment:
+          JVM_OPTS: -Xmx3200m
+
+    working_directory: ~/adb-enhanced-code-checkout-directory
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "requirements.txt" }}-28
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: Install Python dependencies
+          command: |
+            sudo apt-get install python3 python3-pip python3-venv
+            # Setup python3
+            python3 -m venv venv
+            . venv/bin/activate
+            pip3 install -r requirements.txt
+
+      - run:
+          name: Setup Android emulator
+          command: |
+            # echo "Listing of /opt/android/sdk"
+            # ls /opt/android/sdk
+            set -e
+            sdkmanager "system-images;android-16;default;armeabi-v7a"
+            echo "no" | avdmanager create avd -n test -k "system-images;android-16;default;armeabi-v7a"
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}-28
+
+      - run:
+          name: Launch emulator
+          command: export LD_LIBRARY_PATH=${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/qt/lib && emulator64-arm -avd test -noaudio -no-boot-anim -no-window -accel on
+          background: true
+
+      - run:
+          name: Wait for emulator
+          command: circle-android wait-for-boot
+
+      - run:
+          name: Python 3 tests
+          command: |
+            # Any failure is a failure
+            set -e
+            python3 -m venv venv
+            . venv/bin/activate
+            # echo "Doing an ls"
+            python3 -m pytest -v tests/adbe_tests.py  --durations=0
+
+  test-python3-android-api-22:
     docker:
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -131,7 +194,9 @@ jobs:
             # echo "Listing of /opt/android/sdk"
             # ls /opt/android/sdk
             # I tried API 25 but it is too slow and times out on Circle CI
-            sdkmanager "system-images;android-22;default;armeabi-v7a" && echo "no" | avdmanager create avd -n test -k "system-images;android-22;default;armeabi-v7a"
+            set -e
+            sdkmanager "system-images;android-22;default;armeabi-v7a"
+            echo "no" | avdmanager create avd -n test -k "system-images;android-22;default;armeabi-v7a"
 
       - save_cache:
           paths:
@@ -157,6 +222,71 @@ jobs:
             # echo "Doing an ls"
             python3 -m pytest -v tests/adbe_tests.py  --durations=0
 
+  test-python3-android-api-24:
+    docker:
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: circleci/android:api-28-alpha
+        environment:
+          JVM_OPTS: -Xmx3200m
+
+    working_directory: ~/adb-enhanced-code-checkout-directory
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "requirements.txt" }}-28
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: Install Python dependencies
+          command: |
+            sudo apt-get install python3 python3-pip python3-venv
+            # Setup python3
+            python3 -m venv venv
+            . venv/bin/activate
+            pip3 install -r requirements.txt
+
+      - run:
+          name: Setup Android emulator
+          command: |
+            # echo "Listing of /opt/android/sdk"
+            # ls /opt/android/sdk
+            # I tried API 25 but it is too slow and times out on Circle CI
+            set -e
+            sdkmanager "system-images;android-24;default;armeabi-v7a"
+            echo "no" | avdmanager create avd -n test -k "system-images;android-24;default;armeabi-v7a"
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}-28
+
+      - run:
+          name: Launch emulator
+          command: export LD_LIBRARY_PATH=${ANDROID_HOME}/emulator/lib64:${ANDROID_HOME}/emulator/lib64/qt/lib && emulator64-arm -avd test -noaudio -no-boot-anim -no-window -accel on
+          background: true
+
+      - run:
+          name: Wait for emulator
+          command: circle-android wait-for-boot
+
+      - run:
+          name: Test doze
+          command: |
+            # Any failure is a failure
+            set -e
+            python3 -m venv venv
+            . venv/bin/activate
+            # echo "Doing an ls"
+            # test_permissions hangs on Circle CI
+            python3 -m pytest -v tests/adbe_tests.py  --durations=0 -k 'test_doze'
+
 # https://discuss.circleci.com/t/how-to-test-multiple-versions-by-triggering-jobs-with-a-shell-function/11305
 workflows:
   version: 2
@@ -165,4 +295,8 @@ workflows:
       - setup-python2
       - setup-python3
       - test-python2
-      - test-python3
+      - test-python3-android-api-16
+      - test-python3-android-api-22
+      - test-python3-android-api-24
+      # Note: I tried API 25 as well but it is too slow to boot - https://circleci.com/gh/ashishb/adb-enhanced/251
+      # API 26 onwards, only X86 images are available and emulator-x86 simply does not work on Circle CI.

--- a/tests/adbe_tests.py
+++ b/tests/adbe_tests.py
@@ -3,8 +3,12 @@ import subprocess
 import sys
 import os
 
-# Doze mode was launched in API 23.
+# Deut overdraw mode was added in API 19
+_DEUT_ANDROID_VERSION = 19
+# Doze mode was launched in API 23
 _DOZE_MODE_ANDROID_VERSION = 23
+# Runtime permissions were added in API 23
+_RUNTIME_PERMISSIONS_SUPPORTED = 23
 
 _PYTHON_CMD = 'python'
 if sys.version_info >= (3, 0):
@@ -27,7 +31,10 @@ def test_gfx():
 def test_overdraw():
     _assert_success('overdraw on')
     _assert_success('overdraw off')
-    _assert_success('overdraw deut')
+    if _get_device_sdk_version() >= _DEUT_ANDROID_VERSION:
+        _assert_success('overdraw deut')
+    else:
+        _assert_fail('overdraw deut')
     _assert_success('overdraw off')
 
 
@@ -76,17 +83,20 @@ def test_animations():
     _assert_success('animations off')
 
 
-def test_permissions():
+def test_permissions_list():
     _assert_success('permission-groups list all')
     _assert_success('permissions list all')
     _assert_success('permissions list dangerous')
 
-    sdk_version = _get_device_sdk_version()
+
+def test_permissions_grant_revoke():
     test_app_id = 'com.android.phone'
+
     permissions_groups = ['calendar', 'camera', 'contacts', 'location', 'microphone', 'phone', 'sensors',
                          'sms', 'storage']
+
     for permission_group in permissions_groups:
-        if sdk_version >= 23:
+        if _get_device_sdk_version() >= _RUNTIME_PERMISSIONS_SUPPORTED:
             _assert_success('permissions grant %s %s' % (test_app_id, permission_group))
             _assert_success('permissions revoke %s %s' % (test_app_id, permission_group))
         else:
@@ -297,7 +307,8 @@ def main():
     test_mobile_data()
     test_rtl()
     test_animations()
-    test_permissions()
+    test_permissions_list()
+    test_permissions_grant_revoke()
     test_apps()
     test_app_start_related_cmds()
     test_app_info_related_cmds()


### PR DESCRIPTION
Add API 16 and 24 testing to Circle CI. All tests enabled on API 16. Only doze testing enabled on API 24. I want to do permissions testing on API 24 but Circle CI hangs on that. I will address that some other day.