### PR TITLE
Freeze Pytest version to 4.6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -232,7 +232,7 @@ matrix:
         # Python setup
         - cp README.md release
         - cp -r src/* release/adbe/
-        - sudo pip3 install pytest
+        - sudo pip3 install pytest==4.6.4
         - sudo python3 -m pip install --upgrade pip
         - sudo python3 -m pip install -e release
         # Immediate test

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ asyncio
 docopt
 future
 psutil
-pytest
+pytest==4.6.4


### PR DESCRIPTION
Pytest 4.6.4 works. Freeze that for testing on Travis CI. The newer version of pytest seems
to be incompatible with Python 3.5 and fails on Travis CI. I cannot
upgrade Python version on Travis CI since it seems 3.5 is the latest
version available for `android` docker images.

Failure:
https://travis-ci.org/ashishb/adb-enhanced/builds/551900301