### PR TITLE
Test API 16

### DIFF
--- a/.github/workflows/adbe-unittests-python3-old.yml
+++ b/.github/workflows/adbe-unittests-python3-old.yml
@@ -1,0 +1,29 @@
+name: AdbeUnitTestsPython3OldApis
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        # https://github.com/ashishb/adb-enhanced/pull/100/checks?check_run_id=492546108
+        api-level: [16]  # 15 and 19 don't work
+        target: [default] # Other option: google_apis
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86
+          profile: Nexus 6
+          script: |
+            python3 -m pip install --upgrade pip
+            python3 -m pip install --user -r requirements.txt
+            echo "Wait for device"
+            adb wait-for-device
+            echo "Run the tests"
+            python3 -m pytest -v tests/adbe_tests.py  --durations=0


### PR DESCRIPTION
Now, that the GitHub Actions library which we rely upon supports that
https://github.com/ReactiveCircus/android-emulator-runner/pull/28