### PR TITLE
Remove asyncio

### DIFF
--- a/release/setup.py
+++ b/release/setup.py
@@ -30,7 +30,6 @@ setup(name='adb-enhanced',
       zip_safe=True,
       install_requires=[
           # -*- Extra requirements: -*-
-          'asyncio',
           'docopt',
           'future',
           'psutil',


### PR DESCRIPTION
`asyncio` is a [Python standard lib](https://docs.python.org/3.7/library/asyncio.html). 