### PR TITLE
Add individual tests for Api 22 to 29

### DIFF
--- a/.github/workflows/adbe-unittests-python3-api21.yml
+++ b/.github/workflows/adbe-unittests-python3-api21.yml
@@ -1,0 +1,27 @@
+name: AdbeUnitTestsPython3-Api21
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Sunday midnight UTC
+
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [21]
+        target: [default]  # Other option: google_apis
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: Nexus 6
+          script: |
+            python3 -m pip install --upgrade pip
+            python3 -m pip install --user -r requirements.txt
+            make test_python3

--- a/.github/workflows/adbe-unittests-python3-api22.yml
+++ b/.github/workflows/adbe-unittests-python3-api22.yml
@@ -1,0 +1,27 @@
+name: AdbeUnitTestsPython3-Api22
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Sunday midnight UTC
+
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [22]
+        target: [default]  # Other option: google_apis
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: Nexus 6
+          script: |
+            python3 -m pip install --upgrade pip
+            python3 -m pip install --user -r requirements.txt
+            make test_python3

--- a/.github/workflows/adbe-unittests-python3-api23.yml
+++ b/.github/workflows/adbe-unittests-python3-api23.yml
@@ -1,0 +1,27 @@
+name: AdbeUnitTestsPython3-Api23
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Sunday midnight UTC
+
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [23]
+        target: [default]  # Other option: google_apis
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: Nexus 6
+          script: |
+            python3 -m pip install --upgrade pip
+            python3 -m pip install --user -r requirements.txt
+            make test_python3

--- a/.github/workflows/adbe-unittests-python3-api24.yml
+++ b/.github/workflows/adbe-unittests-python3-api24.yml
@@ -1,0 +1,27 @@
+name: AdbeUnitTestsPython3-Api24
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Sunday midnight UTC
+
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [24]
+        target: [default]  # Other option: google_apis
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: Nexus 6
+          script: |
+            python3 -m pip install --upgrade pip
+            python3 -m pip install --user -r requirements.txt
+            make test_python3

--- a/.github/workflows/adbe-unittests-python3-api25.yml
+++ b/.github/workflows/adbe-unittests-python3-api25.yml
@@ -1,4 +1,4 @@
-name: AdbeUnitTestsPython3Scheduled
+name: AdbeUnitTestsPython3-Api25
 
 on:
   schedule:
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        api-level: [21, 22, 23, 24, 25, 26, 27, 28]
+        api-level: [25]
         target: [default]  # Other option: google_apis
     steps:
       - name: checkout

--- a/.github/workflows/adbe-unittests-python3-api26.yml
+++ b/.github/workflows/adbe-unittests-python3-api26.yml
@@ -1,0 +1,27 @@
+name: AdbeUnitTestsPython3-Api26
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Sunday midnight UTC
+
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [26]
+        target: [default]  # Other option: google_apis
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: Nexus 6
+          script: |
+            python3 -m pip install --upgrade pip
+            python3 -m pip install --user -r requirements.txt
+            make test_python3

--- a/.github/workflows/adbe-unittests-python3-api27.yml
+++ b/.github/workflows/adbe-unittests-python3-api27.yml
@@ -1,0 +1,27 @@
+name: AdbeUnitTestsPython3-Api27
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Sunday midnight UTC
+
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [27]
+        target: [default]  # Other option: google_apis
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: Nexus 6
+          script: |
+            python3 -m pip install --upgrade pip
+            python3 -m pip install --user -r requirements.txt
+            make test_python3

--- a/.github/workflows/adbe-unittests-python3-api28.yml
+++ b/.github/workflows/adbe-unittests-python3-api28.yml
@@ -1,0 +1,27 @@
+name: AdbeUnitTestsPython3-Api28
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Sunday midnight UTC
+
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [28]
+        target: [default]  # Other option: google_apis
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: Nexus 6
+          script: |
+            python3 -m pip install --upgrade pip
+            python3 -m pip install --user -r requirements.txt
+            make test_python3

--- a/.github/workflows/adbe-unittests-python3-api29.yml
+++ b/.github/workflows/adbe-unittests-python3-api29.yml
@@ -1,0 +1,27 @@
+name: AdbeUnitTestsPython3-Api29
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Sunday midnight UTC
+
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [29]
+        target: [default]  # Other option: google_apis
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: run tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: Nexus 6
+          script: |
+            python3 -m pip install --upgrade pip
+            python3 -m pip install --user -r requirements.txt
+            make test_python3


### PR DESCRIPTION
The combined test would fail due to one of the tests components failing
and that would cause a lot of trouble. So, best is to separate tests
into different, so that, they can be run individually.