### PR TITLE
Uninstall automatic fallback to first user

### DIFF
--- a/adbe/adb_enhanced.py
+++ b/adbe/adb_enhanced.py
@@ -1508,7 +1508,7 @@ def perform_uninstall(app_name, first_user):
         return
 
     if not cmd:
-        print("Uninstall failed, retry with first user")
+        print_message("Uninstall failed, trying to uninstall for user 0...")
         cmd = "--user 0"
         return_code, _, stderr = execute_adb_shell_command2('pm uninstall %s %s' % (cmd, app_name))
 

--- a/adbe/adb_enhanced.py
+++ b/adbe/adb_enhanced.py
@@ -1504,6 +1504,14 @@ def perform_uninstall(app_name, first_user):
         # https://www.xda-developers.com/uninstall-carrier-oem-bloatware-without-root-access/
         cmd = "--user 0"
     return_code, _, stderr = execute_adb_shell_command2('pm uninstall %s %s' % (cmd, app_name))
+    if return_code == 0:
+        return
+
+    if not cmd:
+        print("Uninstall failed, retry with first user")
+        cmd = "--user 0"
+        return_code, _, stderr = execute_adb_shell_command2('pm uninstall %s %s' % (cmd, app_name))
+
     if return_code != 0:
         print_error('Failed to uninstall %s, stderr: %s' % (app_name, stderr))
 


### PR DESCRIPTION
Uninstall automatic fallback to first user in case the regular uninstall command fails.