### PR TITLE
Code cleanup related to state change

### DIFF
--- a/adbe/main.py
+++ b/adbe/main.py
@@ -2,7 +2,6 @@
 
 import sys
 import os
-import time
 
 import docopt
 
@@ -11,13 +10,13 @@ try:
     # First try local import for development
     from adbe import adb_enhanced
     from adbe import adb_helper
-    from adbe.output_helper import print_error_and_exit, print_message, set_verbose
+    from adbe.output_helper import print_error_and_exit, set_verbose
 # Python 3.6 onwards, this throws ModuleNotFoundError
 except (ImportError, ModuleNotFoundError):
     # This works when the code is executed as a part of the module
     import adb_enhanced
     import adb_helper
-    from output_helper import print_error_and_exit, print_message, set_verbose
+    from output_helper import print_error_and_exit, set_verbose
 
 # List of things which this enhanced adb tool does as of today.
 USAGE_STRING = """
@@ -161,11 +160,7 @@ def main():
 
     # battery
     elif args['battery'] and args['saver']:
-        current_state = adb_enhanced.get_battery_saver_state()
         adb_enhanced.handle_battery_saver(args['on'])
-        new_state = adb_enhanced.get_battery_saver_state()
-        print_state_change_info('Battery saver', current_state, new_state)
-
     elif args['battery'] and args['level']:
         adb_enhanced.handle_battery_level(int(args['<percentage>']))
     elif args['battery'] and args['reset']:
@@ -190,24 +185,12 @@ def main():
 
     # mobile-data
     elif args['mobile-data'] and args['saver']:
-        current_state = adb_enhanced.get_mobile_data_saver_state()
         adb_enhanced.handle_mobile_data_saver(args['on'])
-        new_state = adb_enhanced.get_mobile_data_saver_state()
-        print_state_change_info('Mobile data saver', current_state, new_state)
-
     elif args['mobile-data']:
-        current_state = adb_enhanced.get_mobile_data_state()
         adb_enhanced.handle_mobile_data(args['on'])
-        # sleep before getting the new value or you will get a stale value
-        time.sleep(1)
-        new_state = adb_enhanced.get_mobile_data_state()
-        print_state_change_info('Mobile data', current_state, new_state)
 
     elif args['wifi']:
-        current_state = adb_enhanced.get_wifi_state()
         adb_enhanced.set_wifi(args['on'])
-        new_state = adb_enhanced.get_wifi_state()
-        print_state_change_info('Wi-Fi', current_state, new_state)
 
     elif args['rtl']: # This is not working as expected
         adb_enhanced.force_rtl(args['on'])
@@ -216,26 +199,14 @@ def main():
     elif args['screenrecord']:
         adb_enhanced.dump_screenrecord(args['<filename.mp4>'])
     elif args['dont-keep-activities']:
-        current_state = adb_enhanced.get_dont_keep_activities_in_background_state()
         adb_enhanced.handle_dont_keep_activities_in_background(args['on'])
-        new_state = adb_enhanced.get_dont_keep_activities_in_background_state()
-        print_state_change_info('Don\'t keep activities', current_state, new_state)
-
     elif args['animations']:
         adb_enhanced.toggle_animations(args['on'])
     elif args['show-taps']:
-        current_state = adb_enhanced.get_show_taps_state()
         adb_enhanced.toggle_show_taps(args['on'])
-        new_state = adb_enhanced.get_show_taps_state()
-        print_state_change_info('Show user taps', current_state, new_state)
-
     elif args['stay-awake-while-charging']:
-        current_state = adb_enhanced.get_stay_awake_while_charging_state()
         # Keep screen on while the device is charging.
         adb_enhanced.stay_awake_while_charging(args['on'])
-        new_state = adb_enhanced.get_stay_awake_while_charging_state()
-        print_state_change_info('Stay awake while charging', current_state, new_state)
-
     elif args['input-text']:
         adb_enhanced.input_text(args['<text>'])
     elif args['back']:
@@ -378,13 +349,6 @@ def main():
 
     else:
         print_error_and_exit('Not implemented: "%s"' % ' '.join(sys.argv))
-
-
-def print_state_change_info(state_name, old_state, new_state):
-    if old_state != new_state:
-        print_message('\"%s\" state changed from "%s" -> "%s"' % (state_name, old_state, new_state))
-    else:
-        print_message('\"%s\" state unchanged (%s)' % (state_name, old_state))
 
 
 def validate_options(args):


### PR DESCRIPTION
Earlier, quite a few functions that used to print state modifications
were reading the previous/next state manually

Now, automate that code with a python decorator. This reduces the code
as well makes main.py smaller.

Long term, I want to reduce logic in main.py, so that, `docopt` argument
parsing library can be replaced by a better library.