### PR TITLE
Replace `description-file` -> `description_file`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Replace `description-file` -> `description_file` in `setup.cfg`

```
Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
```