### PR TITLE
Add location

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ adbe [options] enable wireless debugging
 adbe [options] disable wireless debugging
 adbe [options] screen (on | off | toggle)
 adbe [options] alarm (all | top | pending | history)
+adbe [options] location (on | off)
 ```
 
 ### Options

--- a/adbe/adb_enhanced.py
+++ b/adbe/adb_enhanced.py
@@ -53,6 +53,7 @@ except ImportError:
 _KEYCODE_BACK = 4
 _MIN_API_FOR_RUNTIME_PERMISSIONS = 23
 _MIN_API_FOR_DARK_MODE = 29
+_MIN_API_FOR_LOCATION = 29
 
 _REGEX_BACKUP_ALLOWED = '(pkgFlags|flags).*ALLOW_BACKUP'
 _REGEX_DEBUGGABLE = '(pkgFlags|flags).*DEBUGGABLE'
@@ -2063,6 +2064,14 @@ def alarm_manager(param):
         else:
             print_error(err_msg_api)
 
+
+def toggle_location(turn_on):
+    _error_if_min_version_less_than(_MIN_API_FOR_LOCATION)
+    if turn_on:
+        cmd = 'put secure location_mode 3'
+    else:
+        cmd = 'put secure location_mode 0'
+    execute_adb_shell_settings_command(cmd)
 
 # This permissions group seems to have been removed in API 29 and beyond.
 # https://github.com/ashishb/adb-enhanced/runs/1799363523?check_suite_focus=true

--- a/adbe/main.py
+++ b/adbe/main.py
@@ -80,6 +80,7 @@ Usage:
     adbe [options] disable wireless debugging
     adbe [options] screen (on | off | toggle)
     adbe [options] alarm (all | top | pending | history)
+    adbe [options] location (on | off)
 
 Options:
     -e, --emulator          directs the command to the only running emulator
@@ -345,6 +346,9 @@ def main():
         adb_enhanced.alarm_manager(adb_enhanced.AlarmEnum.PENDING)
     elif args['alarm'] and args['top']:
         adb_enhanced.alarm_manager(adb_enhanced.AlarmEnum.TOP)
+
+    elif args['location']:
+        adb_enhanced.toggle_location(args['on'])
 
     else:
         print_error_and_exit('Not implemented: "%s"' % ' '.join(sys.argv))

--- a/tests/adbe_tests.py
+++ b/tests/adbe_tests.py
@@ -15,6 +15,8 @@ _DOZE_MODE_ANDROID_VERSION = 23
 _RUNTIME_PERMISSIONS_SUPPORTED = 23
 # Dark mode was added in API 29
 _DARK_MODE_ANDROID_VERSION = 29
+# The command to change location does not work below API 29
+_LOCATION_CHANGE_ANDROID_VERSION = 29
 
 _PYTHON_CMD = 'python'
 if sys.version_info >= (3, 0):
@@ -444,8 +446,12 @@ def test_notifications():
 
 
 def test_location():
-    _assert_success("location on")
-    _assert_success("location off")
+    if _get_device_sdk_version() >= _LOCATION_CHANGE_ANDROID_VERSION:
+        check = _assert_success
+    else:
+        check = _assert_fail
+    check("location on")
+    check("location off")
 
 
 def _assert_fail(sub_cmd):

--- a/tests/adbe_tests.py
+++ b/tests/adbe_tests.py
@@ -443,6 +443,11 @@ def test_notifications():
     _assert_success('notifications list')
 
 
+def test_location():
+    _assert_success("location on")
+    _assert_success("location off")
+
+
 def _assert_fail(sub_cmd):
     exit_code, stdout_data, stderr_data = _execute(sub_cmd)
     assert exit_code == 1, 'Command "%s" failed with stdout: "%s" and stderr: "%s"' %(sub_cmd, stdout_data, stderr_data)
@@ -531,6 +536,7 @@ def main():
     test_wireless()
     test_screen_toggle()
     test_notifications()
+    test_location()
     # TODO: Add a test for screen record after figuring out how to perform ^C while it is running.
 
 


### PR DESCRIPTION
Clone of https://github.com/ashishb/adb-enhanced/pull/167 with a fix to the testing code.

Original PR message:

I've tested it in Android 10 (API 29), Android 11 (API 30), and Android 12 (API 32).

For versions lower than API 29 the command doesn't work, and we have to use `location_providers_allowed`. But it gets complicated because we have 3 modes: battery saving, phone only, and high accuracy. And the command doesn't seem to be reliable. I leave it for another PR.

This closes #166 