### PR TITLE
Increase minimum version requirement to Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,5 @@ setup(name='adb-enhanced',
           # -*- Entry points: -*-
           'console_scripts': ['adbe=adbe.main:main'],
       },
-      python_requires='>=3.4'
+      python_requires='>=3.6'
       )


### PR DESCRIPTION
Increase minimum version requirement from 3.4 -> 3.6
https://devguide.python.org/versions/