### PR TITLE
ci: switch from `macos-latest` -> `ubuntu-latest` + KVM

### DIFF
--- a/.github/workflows/adbe-unittests-api16.yml
+++ b/.github/workflows/adbe-unittests-api16.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   testOnAndroidApi16:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     # This test is slower compared to the other tests
     timeout-minutes: 20
 
@@ -37,6 +37,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/adbe-unittests-api21.yml
+++ b/.github/workflows/adbe-unittests-api21.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -25,6 +25,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/adbe-unittests-api22.yml
+++ b/.github/workflows/adbe-unittests-api22.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   testOnApi22:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -25,6 +25,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/adbe-unittests-api23.yml
+++ b/.github/workflows/adbe-unittests-api23.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   testOnAp23:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -25,6 +25,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/adbe-unittests-api24.yml
+++ b/.github/workflows/adbe-unittests-api24.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   testOnApi24:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -28,6 +28,13 @@ jobs:
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api25.yml
+++ b/.github/workflows/adbe-unittests-api25.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   testOnApi25:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -25,6 +25,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/adbe-unittests-api26.yml
+++ b/.github/workflows/adbe-unittests-api26.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   testOnApi26:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -25,6 +25,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/adbe-unittests-api27.yml
+++ b/.github/workflows/adbe-unittests-api27.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   testOnApi27:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -25,6 +25,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/adbe-unittests-api28.yml
+++ b/.github/workflows/adbe-unittests-api28.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   testOnApi28:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -25,6 +25,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/adbe-unittests-api29.yml
+++ b/.github/workflows/adbe-unittests-api29.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   testOnApi29:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -25,6 +25,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/adbe-unittests-api30.yml
+++ b/.github/workflows/adbe-unittests-api30.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   testOnApi30:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -28,6 +28,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/adbe-unittests-api31.yml
+++ b/.github/workflows/adbe-unittests-api31.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   testOnApi31:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     strategy:
@@ -28,6 +28,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/adbe-unittests-api32.yml
+++ b/.github/workflows/adbe-unittests-api32.yml
@@ -30,6 +30,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/adbe-unittests-api33.yml
+++ b/.github/workflows/adbe-unittests-api33.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   testOnApi33:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     # This test is slow
     timeout-minutes: 30
 
@@ -31,6 +31,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/adbe-unittests-api34.yml
+++ b/.github/workflows/adbe-unittests-api34.yml
@@ -30,6 +30,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/adbe-unittests.yml
+++ b/.github/workflows/adbe-unittests.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   unittestsApi21And26:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     strategy:

--- a/.github/workflows/install-adb-enhanced-from-homebrew.yml
+++ b/.github/workflows/install-adb-enhanced-from-homebrew.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Install adb-enhanced from homebrew
         run: |
-          # TODO(ashishb): Remove update after Aug 1, 2023
-          brew update || echo "brew update failed, still proceeding"
           brew link --force python@3.11
           HOMEBREW_NO_INSTALL_CLEANUP=true brew install --verbose adb-enhanced || echo "brew install returned non-zero exit code"
           adbe --version


### PR DESCRIPTION
As per
https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners, these are faster.

In our case, the speed-up seems to be 2-3X faster executions.