### PR TITLE
ci: replace deprecate Gradle action

### DIFF
--- a/.github/workflows/adbe-installtests.yml
+++ b/.github/workflows/adbe-installtests.yml
@@ -47,7 +47,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api16.yml
+++ b/.github/workflows/adbe-unittests-api16.yml
@@ -46,7 +46,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api21.yml
+++ b/.github/workflows/adbe-unittests-api21.yml
@@ -34,7 +34,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api22.yml
+++ b/.github/workflows/adbe-unittests-api22.yml
@@ -34,7 +34,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api23.yml
+++ b/.github/workflows/adbe-unittests-api23.yml
@@ -34,7 +34,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api24.yml
+++ b/.github/workflows/adbe-unittests-api24.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       # Ref: https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
       - name: Enable KVM

--- a/.github/workflows/adbe-unittests-api25.yml
+++ b/.github/workflows/adbe-unittests-api25.yml
@@ -34,7 +34,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api28.yml
+++ b/.github/workflows/adbe-unittests-api28.yml
@@ -34,7 +34,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api29.yml
+++ b/.github/workflows/adbe-unittests-api29.yml
@@ -38,7 +38,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api30.yml
+++ b/.github/workflows/adbe-unittests-api30.yml
@@ -37,7 +37,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4


### PR DESCRIPTION
`gradle/gradle-build-action@v3` -> `gradle/actions/setup-gradle@v3`

Ref: https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle