### PR TITLE
ci: replace deprecate Gradle action

### DIFF
--- a/.github/workflows/adbe-unittests-api26.yml
+++ b/.github/workflows/adbe-unittests-api26.yml
@@ -38,7 +38,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api27.yml
+++ b/.github/workflows/adbe-unittests-api27.yml
@@ -34,7 +34,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api31.yml
+++ b/.github/workflows/adbe-unittests-api31.yml
@@ -37,7 +37,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api32.yml
+++ b/.github/workflows/adbe-unittests-api32.yml
@@ -38,7 +38,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api33.yml
+++ b/.github/workflows/adbe-unittests-api33.yml
@@ -40,7 +40,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests-api34.yml
+++ b/.github/workflows/adbe-unittests-api34.yml
@@ -38,7 +38,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4

--- a/.github/workflows/adbe-unittests.yml
+++ b/.github/workflows/adbe-unittests.yml
@@ -47,7 +47,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v3
 
       - name: AVD cache
         uses: actions/cache@v4


### PR DESCRIPTION
`gradle/gradle-build-action@v3` -> `gradle/actions/setup-gradle@v3`

Ref: https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle