### PR TITLE
ci: run CI tests on Python 3.12

### DIFF
--- a/.github/workflows/adbe-unittests.yml
+++ b/.github/workflows/adbe-unittests.yml
@@ -29,6 +29,7 @@ jobs:
     timeout-minutes: 30
 
     strategy:
+      max-parallel: 1
       matrix:
         api-level: [21, 26]
         target: [default]  # Other option: google_apis

--- a/.github/workflows/install-adb-enhanced-from-pip.yml
+++ b/.github/workflows/install-adb-enhanced-from-pip.yml
@@ -22,10 +22,9 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     strategy:
+      max-parallel: 1
       matrix:
-        # A dependency, psutil, fails to install on Python 3.9
-        # https://github.com/ashishb/adb-enhanced/actions/runs/4309805993/jobs/7517607875
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.11", "3.12"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -25,8 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      max-parallel: 1
       matrix:
-        python-version: ["3.8", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -46,5 +47,5 @@ jobs:
       - name: Lint
         run: |
           pip install -r requirements.txt
-          pip install pylint flake8
+          pip install pylint flake8 setuptools
           make lint_python3


### PR DESCRIPTION
Reduce parallelism to fail early and save CI time