### PR TITLE
chore: `test_python3` -> `test_python` and `lint_python3` -> `lint_python`

### DIFF
--- a/.github/workflows/adbe-installtests.yml
+++ b/.github/workflows/adbe-installtests.yml
@@ -88,4 +88,4 @@ jobs:
             ls $(python3 -m site --user-base)/bin/adbe
             $(python3 -m site --user-base)/bin/adbe --version
             PATH=$PATH:$(python3 -m site --user-base)/bin adbe --version  # Verify adbe is installed
-            PATH=$PATH:$(python3 -m site --user-base)/bin make test_python3_installation
+            PATH=$PATH:$(python3 -m site --user-base)/bin make test_python_installation

--- a/.github/workflows/adbe-unittests-api16.yml
+++ b/.github/workflows/adbe-unittests-api16.yml
@@ -81,4 +81,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
           target: ${{ matrix.target }}
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api21.yml
+++ b/.github/workflows/adbe-unittests-api21.yml
@@ -67,4 +67,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
           target: ${{ matrix.target }}
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api22.yml
+++ b/.github/workflows/adbe-unittests-api22.yml
@@ -67,4 +67,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
           target: ${{ matrix.target }}
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api23.yml
+++ b/.github/workflows/adbe-unittests-api23.yml
@@ -67,4 +67,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
           target: ${{ matrix.target }}
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api24.yml
+++ b/.github/workflows/adbe-unittests-api24.yml
@@ -67,4 +67,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
           target: ${{ matrix.target }}
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api25.yml
+++ b/.github/workflows/adbe-unittests-api25.yml
@@ -67,4 +67,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
           target: ${{ matrix.target }}
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api26.yml
+++ b/.github/workflows/adbe-unittests-api26.yml
@@ -74,4 +74,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -no-metrics -camera-back none
           disable-animations: true
           target: ${{ matrix.target }}
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api27.yml
+++ b/.github/workflows/adbe-unittests-api27.yml
@@ -67,4 +67,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -no-metrics -camera-back none
           disable-animations: true
           target: ${{ matrix.target }}
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api28.yml
+++ b/.github/workflows/adbe-unittests-api28.yml
@@ -67,4 +67,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
           target: ${{ matrix.target }}
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api29.yml
+++ b/.github/workflows/adbe-unittests-api29.yml
@@ -71,4 +71,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
           target: ${{ matrix.target }}
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api30.yml
+++ b/.github/workflows/adbe-unittests-api30.yml
@@ -73,4 +73,4 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api31.yml
+++ b/.github/workflows/adbe-unittests-api31.yml
@@ -73,4 +73,4 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api32.yml
+++ b/.github/workflows/adbe-unittests-api32.yml
@@ -74,4 +74,4 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -no-metrics -camera-back none
           disable-animations: true
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests-api33.yml
+++ b/.github/workflows/adbe-unittests-api33.yml
@@ -76,4 +76,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -no-metrics -camera-back none
           disable-animations: true
           script: |
-            make test_python3
+            make test_python

--- a/.github/workflows/adbe-unittests-api34.yml
+++ b/.github/workflows/adbe-unittests-api34.yml
@@ -74,4 +74,4 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -no-metrics -camera-back none
           disable-animations: true
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/adbe-unittests.yml
+++ b/.github/workflows/adbe-unittests.yml
@@ -83,4 +83,4 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-metrics -camera-back none
           disable-animations: true
           target: ${{ matrix.target }}
-          script: make test_python3
+          script: make test_python

--- a/.github/workflows/lint-python.yaml
+++ b/.github/workflows/lint-python.yaml
@@ -42,4 +42,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Lint
-        run: make lint_python3
+        run: make lint_python

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-lint: lint_python3 lint_markdown
+lint: lint_python lint_markdown
 
 test: test_python3
 
@@ -33,7 +33,7 @@ format:
 	uv run isort --line-length 88 --skip-gitignore adbe
 	uv run isort --line-length 88 --skip-gitignore tests
 
-lint_python3:
+lint_python:
 	uv run -- autoflake --check-diff -r --quiet --remove-all-unused-imports --remove-unused-variables adbe
 	# Fail if there are Python syntax errors or undefined names
 	uv run -- flake8 adbe --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -58,13 +58,13 @@ lint_python3:
 
 # To run a single test, for example, test_file_move3, try this
 # python3 -m pytest -v tests/adbe_tests.py -k test_file_move3
-test_python3:
+test_python:
 	echo "Wait for device"
 	adb wait-for-device
 	echo "Run the tests"
 	uv run -- pytest -v tests/adbe_tests.py  # Python3 tests
 
-test_python3_installation:
+test_python_installation:
 	echo "Wait for device"
 	adb wait-for-device
 	echo "Run the tests"


### PR DESCRIPTION
There is no Python 2 anymore.
And hopefully, there won't be Python 4.